### PR TITLE
Fix/65 load game timer

### DIFF
--- a/__tests__/reducer.test.ts
+++ b/__tests__/reducer.test.ts
@@ -9,49 +9,117 @@ describe("Reducer", () => {
   });
 
   describe("Tick", () => {
-    it("should update the state's msElapsed and lastTick properties", () => {
-      const interimState = reducer(
-        { ...initialState, loading: false, lastTick: 0 },
-        {
-          type: ActionType.Tick,
-          payload: 1000,
-        }
-      );
-      const state = reducer(interimState, {
-        type: ActionType.Tick,
-        payload: 2000,
-      });
+    jest.useFakeTimers();
 
-      expect(state).toEqual({
-        ...initialState,
-        loading: false,
-        msElapsed: 2000,
-        lastTick: 2000,
-      });
+    it("should update the state's msElapsed and lastTick properties", () => {
+      jest.advanceTimersByTime(1000);
+      const state = reducer(
+        { ...initialState, loading: false, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.msElapsed).toBe(1000);
+      expect(state.lastTick).toBe(1000);
     });
 
-    it("should not update the timer while the document is hidden", () => {
-      const interimState = reducer(
+    it("should never increment by more than 1 second", () => {
+      jest.advanceTimersByTime(10000);
+      const state = reducer(
         { ...initialState, loading: false, lastTick: 0 },
-        {
-          type: ActionType.Tick,
-          payload: 1000,
-        }
+        { type: ActionType.Tick }
       );
 
+      expect(state.msElapsed).toBe(1000);
+    });
+
+    it("should not update the elapsed time while the document is hidden", () => {
+      jest.advanceTimersByTime(1000);
       jest.spyOn(document, "hidden", "get").mockReturnValue(true);
 
-      const state = reducer(interimState, {
-        type: ActionType.Tick,
-        payload: 2000,
-      });
+      const state = reducer(
+        { ...initialState, loading: false, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
 
-      expect(state).toEqual({
-        ...initialState,
-        loading: false,
-        msElapsed: 1000,
-        lastTick: 2000,
-      });
+      expect(state.msElapsed).toBe(initialState.msElapsed);
+    });
+
+    it("should update the last tick while the document is hidden", () => {
+      jest.advanceTimersByTime(1000);
+      jest.spyOn(document, "hidden", "get").mockReturnValue(true);
+
+      const state = reducer(
+        { ...initialState, loading: false, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.lastTick).toBe(1000);
+    });
+
+    it("should not update the elapsed time while loading", () => {
+      jest.advanceTimersByTime(1000);
+
+      const state = reducer(
+        { ...initialState, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.msElapsed).toBe(initialState.msElapsed);
+    });
+
+    it("should update the last tick while loading", () => {
+      jest.advanceTimersByTime(1000);
+
+      const state = reducer(
+        { ...initialState, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.lastTick).toBe(1000);
+    });
+
+    it("should not update the elapsed time after winning", () => {
+      jest.advanceTimersByTime(1000);
+
+      const state = reducer(
+        { ...initialState, loading: false, win: true, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.msElapsed).toBe(initialState.msElapsed);
+    });
+
+    it("should update the last tick after winning", () => {
+      jest.advanceTimersByTime(1000);
+
+      const state = reducer(
+        { ...initialState, loading: false, win: true, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.lastTick).toBe(1000);
+    });
+
+    it("should not update the elapsed time while there is an error", () => {
+      jest.advanceTimersByTime(1000);
+
+      const state = reducer(
+        { ...initialState, loading: false, error: true, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.msElapsed).toBe(initialState.msElapsed);
+    });
+
+    it("should update the last tick while the document is hidden", () => {
+      jest.advanceTimersByTime(1000);
+
+      const state = reducer(
+        { ...initialState, loading: false, error: true, lastTick: 0 },
+        { type: ActionType.Tick }
+      );
+
+      expect(state.lastTick).toBe(1000);
     });
   });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Inter } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import LogoIcon from "@/app/components/icons/LogoIcon";
-import { version } from "../../package.json";
+import pkg from "../../package.json";
 
 const inter = Inter({ subsets: ["latin"] });
 const domain = "cryptoquote-five.vercel.app";
@@ -52,7 +52,7 @@ export default function RootLayout({
 
           <div>
             <a href="https://github.com/Rykus0/cryptoquote/releases/latest">
-              v{version}
+              v{pkg.version}
             </a>
           </div>
         </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  useCallback,
   useEffect,
   useReducer,
   useRef,
@@ -76,18 +75,18 @@ export default function Home() {
     }
   }
 
-  const tick = useCallback(() => {
-    dispatch({ type: ActionType.Tick, payload: Date.now() });
-  }, []);
-
   useEffect(() => {
+    function tick() {
+      dispatch({ type: ActionType.Tick, payload: Date.now() });
+    }
+
     timer.current = setInterval(tick, 100);
 
     return () => {
       window.clearInterval(timer.current);
       timer.current = undefined;
     };
-  }, [tick]);
+  }, []);
 
   useEffect(() => {
     if (loadGame()) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,7 +77,7 @@ export default function Home() {
 
   useEffect(() => {
     function tick() {
-      dispatch({ type: ActionType.Tick, payload: Date.now() });
+      dispatch({ type: ActionType.Tick });
     }
 
     timer.current = setInterval(tick, 100);

--- a/src/app/state/reducer.ts
+++ b/src/app/state/reducer.ts
@@ -26,14 +26,12 @@ export const initialState: State = {
 export default function reducer(state: State, action: Action): State {
   switch (action.type) {
     case ActionType.Tick:
-      const shouldNotTick =
-        document.hidden || state.loading || state.win || state.error;
-      const elapsed = shouldNotTick ? 0 : action.payload - state.lastTick;
+      const currentMs = Date.now();
 
       const tickState = {
         ...state,
-        msElapsed: state.msElapsed + elapsed,
-        lastTick: action.payload,
+        msElapsed: state.msElapsed + getElapsedMs(state, currentMs),
+        lastTick: currentMs,
       };
 
       saveGame(tickState);
@@ -181,4 +179,20 @@ function isCompleteWithError(state: State, newAnswer: Cypher) {
 
 function createEmptyReverseCypher(cypher: Cypher) {
   return new Map(Array.from(cypher.values()).map((v) => [v, ""]));
+}
+
+function getElapsedMs(state: State, currentMs: number) {
+  const shouldNotTick =
+    document.hidden || state.loading || state.win || state.error;
+  const elapsed = currentMs - state.lastTick;
+
+  if (shouldNotTick || elapsed < 0) {
+    return 0;
+  }
+
+  if (elapsed > 1000) {
+    return 1000;
+  }
+
+  return elapsed;
 }

--- a/src/app/state/types.ts
+++ b/src/app/state/types.ts
@@ -39,4 +39,4 @@ export type Action =
       type: ActionType.SetAnswer;
       payload: { encoded: string; decoded: string };
     }
-  | { type: ActionType.Tick; payload: number };
+  | { type: ActionType.Tick };


### PR DESCRIPTION
closes #65 by limiting each tick to a max of 1s
Also refactors the tick action so that the reducer controls the value, rather than accepting it, simplifying the usage of the action. (though since it doesn't control the interval, might want to change this back later)